### PR TITLE
Read DB settings from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # scholae
 App gestion ecole
+
+## Configuration
+
+The database connection settings are read from environment variables. Set the
+following variables when deploying the application:
+
+| Variable    | Description                | Default (local development) |
+|-------------|----------------------------|-----------------------------|
+| `DB_HOST`   | Database host              | `localhost`                 |
+| `DB_USER`   | Database user              | `root`                      |
+| `DB_PASSWORD` | Database password        | *(empty)*                   |
+| `DB_NAME`   | Database name              | `gestecole`                 |
+
+If a variable is not provided, the default value shown above is used. This
+allows the application to run locally without additional configuration.

--- a/bdd_app_gst_connect/config.php
+++ b/bdd_app_gst_connect/config.php
@@ -2,10 +2,16 @@
 /**
  * Voici les détails de connexion à la base de données
  */  
-define("HOST", "localhost");     // L’hébergeur où vous voulez vous connecter.
-define("USER", "root");    // Le nom d’utilisateur de la base de données.
-define("PASSWORD", "");    // Le mot de passe de la base de données. 
-define("DATABASE", "gestecole");    // Le nom de la base de données.
+// Allow overriding configuration via environment variables for flexibility
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASSWORD') ?: '';
+$database = getenv('DB_NAME') ?: 'gestecole';
+
+define("HOST", $host);       // L’hébergeur où vous voulez vous connecter.
+define("USER", $user);       // Le nom d’utilisateur de la base de données.
+define("PASSWORD", $password); // Le mot de passe de la base de données.
+define("DATABASE", $database); // Le nom de la base de données.
 define("CAN_REGISTER", "any");
 define("DEFAULT_ROLE", "member");
 define("SECURE", FALSE);    


### PR DESCRIPTION
## Summary
- allow `bdd_app_gst_connect/config.php` to read DB info from environment variables
- document configuration in the README

## Testing
- `php -l bdd_app_gst_connect/config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867d26370a48320a12d4f58667cde3a