### PR TITLE
Refactor authentication queries

### DIFF
--- a/__php/__authenficationG.php
+++ b/__php/__authenficationG.php
@@ -3,9 +3,12 @@
    function Authenfication($login,$passwd){
         global $bdd;    
         //requette
-        echo 1;  
-        $requete=$bdd->query("SELECT * FROM user WHERE login='$login' AND motp='$passwd' ") or die(print_r($bd));
-        $resultat=$requete->fetch();
+        echo 1;
+        $requete = $bdd->prepare('SELECT * FROM user WHERE login = :login AND motp = :passwd');
+        $requete->bindParam(':login', $login);
+        $requete->bindParam(':passwd', $passwd);
+        $requete->execute();
+        $resultat = $requete->fetch();
         if($resultat == 0){
             echo '<div class="alert alert-danger" id="cont" ><h3><center>Authenfication echouée!</h3></center></p><br /><br />';
          }

--- a/bdd_app_gst_connect/class_authetification.php
+++ b/bdd_app_gst_connect/class_authetification.php
@@ -2,8 +2,11 @@
    function Authenfication($login,$passwd){
 		global $bdd;	
 		//requette
-		$requete = $bdd->query("SELECT * FROM user WHERE login='$login' AND motp='$passwd'");
-		$resultat = $requete->fetch();
+                $requete = $bdd->prepare('SELECT * FROM user WHERE login = :login AND motp = :passwd');
+                $requete->bindParam(':login', $login);
+                $requete->bindParam(':passwd', $passwd);
+                $requete->execute();
+                $resultat = $requete->fetch();
 		if($resultat == 0){
 			echo '<div class="alert alert-danger" id="cont" ><h3><center>Authenfication echouée!</h3></center></p><br /><br />';
 		 }

--- a/php/__authentification.php
+++ b/php/__authentification.php
@@ -4,8 +4,10 @@ require_once('../bdd_app_gst_connect/allscirpt.inc.php');
     function verificationUser($login){
     	global $bdd;
 
-    	$requete = $bdd->query("SELECT * FROM user WHERE login='$login'");
-		$resultat = $requete->fetch();
+        $requete = $bdd->prepare('SELECT * FROM user WHERE login = :login');
+        $requete->bindParam(':login', $login);
+        $requete->execute();
+        $resultat = $requete->fetch();
 		if($resultat == 0){
 			echo 0;
 		}


### PR DESCRIPTION
## Summary
- use PDO prepared statements in authentication functions

## Testing
- `php -l __php/__authenficationG.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d32b6d7c8320b5859cbc8696ea43