### PR TITLE
Add dependency management guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bdd_app_gst_connect/config.php
+vendor/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ following variables when deploying the application:
 
 If a variable is not provided, the default value shown above is used. This
 allows the application to run locally without additional configuration.
+
+## Dependencies
+
+Third-party libraries such as Bootstrap and jQuery should be installed via
+Composer or npm. These dependencies must be placed in the `vendor/` directory,
+which is excluded from version control by the `.gitignore` file. Only
+project-specific assets are committed to the repository.


### PR DESCRIPTION
## Summary
- ignore `vendor/` directory
- document that third-party libraries should live in `vendor/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867ee8db7588320b122f1b3b41cb3eb