### PR TITLE
Fix markup in PHP pages

### DIFF
--- a/ecole/accueil.php
+++ b/ecole/accueil.php
@@ -1,5 +1,5 @@
+<?php include('header.php');?>
 <body>
-	<?php include('header.php');?>
 
 	 <!--formulaire enregistrement frais hors systeme -->
 

--- a/ecole/autres_fact.php
+++ b/ecole/autres_fact.php
@@ -1,5 +1,5 @@
-<body>
 <?php include('header.php');?>
+<body>
 <!--formulaire enregistrement frais hors systeme -->
 	  <div class="row">
 			

--- a/ecole/autres_frais.php
+++ b/ecole/autres_frais.php
@@ -1,5 +1,5 @@
+<?php include('header.php');?>
 <body>
-	<?php include('header.php');?>
 	 <!--formulaire enregistrement frais hors systeme -->
 	 <div class="row">
 			 <div class="col-lg-4">

--- a/ecole/capacite_classe.php
+++ b/ecole/capacite_classe.php
@@ -73,7 +73,7 @@ li{
   <div class="form-group">
 
     <label class="sr-only" for="exampleInputEmail3">Classe</label>
-    <input type="text" class="form-control" id="exampleInputEmail3" placeholder="" value="'.$selection['categorie_classe'].'"" readonly="" name="classe" >
+    <input type="text" class="form-control" id="exampleInputEmail3" value="'.$selection['categorie_classe'].'"" readonly="" name="classe" >
   </div>
   <div class="form-group">
     <label class="sr-only" for="exampleInputPassword3">Frais Inscription</label>

--- a/ecole/classe.php
+++ b/ecole/classe.php
@@ -1,5 +1,4 @@
 <?php include('header.php'); ?>
-</head>
 <body>
   <?php 
       if(isset($_GET['classe'])){ 

--- a/ecole/derogation.php
+++ b/ecole/derogation.php
@@ -83,8 +83,6 @@ label{
 		</div>
 		
 		
-</body>
-</html><br />
 
 
 <?php

--- a/ecole/detailclasse.php
+++ b/ecole/detailclasse.php
@@ -81,9 +81,6 @@ $requete1 = $bdd->query("SELECT* FROM enseignant GROUP BY nomsens");
 		</div>
 		
 		
-</body>
-</html><br />
-
 <?php
 	
 	if (isset($_POST['nomc']) and $_POST['categoriec']!=1) {

--- a/ecole/detaileleves.php
+++ b/ecole/detaileleves.php
@@ -93,9 +93,6 @@ color:royalblue;}
 		</div>
 		
 		
-</body>
-</html><br />
-
 <?php
 
 	include("recherche.php");

--- a/ecole/entete.php
+++ b/ecole/entete.php
@@ -58,24 +58,24 @@ label{
 		</div>
 		
 		
-</body>
-</html><br />
 <?php
-	
-		if (isset($_POST['entete'])) {
-			$date=date('Y-m-d');
-				$entete=htmlentities($_POST['entete']);
-				$slogan=(htmlentities($_POST['slogan']);
-				$site=htmlentities($_POST['site']);
-				$addresse=htmlentities($_POST['addresse']);
-				$tel=htmlentities($_POST['tel']);
-				$mail=htmlentities($_POST['mail']);
-			    $bdd->exec("INSERT INTO info_application  VALUES('','$site','$tel','$addresse','$mail','$entete','$slogan')")or die(print_r($bdd->errorInfo()));
-				echo '<p style="color:green;" align="center">Fait correctement!</p>';
-			
-			}
-		
+
+                if (isset($_POST['entete'])) {
+                        $date=date('Y-m-d');
+                                $entete=htmlentities($_POST['entete']);
+                                $slogan=(htmlentities($_POST['slogan']);
+                                $site=htmlentities($_POST['site']);
+                                $addresse=htmlentities($_POST['addresse']);
+                                $tel=htmlentities($_POST['tel']);
+                                $mail=htmlentities($_POST['mail']);
+                            $bdd->exec("INSERT INTO info_application  VALUES('','$site','$tel','$addresse','$mail','$entete','$slogan')")or die(print_r($bdd->errorInfo()));
+                                echo '<p style="color:green;" align="center">Fait correctement!</p>';
+
+                        }
+
 include("recherche.php");
 
 ?>
 <?php include('footer.php');  ?>
+</body>
+</html>

--- a/ecole/mis_a_jour_min.php
+++ b/ecole/mis_a_jour_min.php
@@ -93,4 +93,4 @@ else{
 	<?php include('footer.php');  ?>	
 		
 </body>
-</html><br />
+</html>

--- a/ecole/modification.php
+++ b/ecole/modification.php
@@ -54,17 +54,16 @@
 		</div>
 		
 		
-</body>
-</html><br />
 <?php
-		if (isset($_POST['nomeleve'])) {
-				$matricule=htmlentities($_POST['nomeleve']);
-				$datedebut= htmlentities($_POST['datedebut']);
-				$datefin=htmlentities($_POST['datefin']);
-				$mois=htmlentities($_POST['mois']);
-				EffectuerUneDerogationEleve($matricule,$datedebut,$datefin,$mois);
-			}
-	include("recherche.php");
-
+                if (isset($_POST['nomeleve'])) {
+                                $matricule=htmlentities($_POST['nomeleve']);
+                                $datedebut= htmlentities($_POST['datedebut']);
+                                $datefin=htmlentities($_POST['datefin']);
+                                $mois=htmlentities($_POST['mois']);
+                                EffectuerUneDerogationEleve($matricule,$datedebut,$datefin,$mois);
+                        }
+        include("recherche.php");
 ?>
 <?php include('footer.php');  ob_flush();?>
+</body>
+</html>

--- a/ecole/suivi_depense.php
+++ b/ecole/suivi_depense.php
@@ -67,9 +67,6 @@ display:table-cell;}
 			</p>
 		</article>
 	</div>
-</body>
-</html><br />
-
 <?php
 	include("connexion.php");
 	if(isset($_POST['rech'])){

--- a/ecole/voir_minerval_classe.php
+++ b/ecole/voir_minerval_classe.php
@@ -56,8 +56,6 @@ display:table-cell;}
 			</p>
 		</article>
 	</div>
-</body>
-</html><br />
 
 <?php
 	if(isset($_POST['rech'])){
@@ -68,7 +66,7 @@ display:table-cell;}
 		echo '<p style="color:red;" align="center">Vide pour cette recherche !</p>';
 	}
 	else{
-		echo '<table class="table table-stripped table-bordered table-condensed" id="cont" style="background-color:white;"><th>N°</th><th>MATRICULE</th><th>NOM</th><th>POSTNOM</th><th>PRENOM</th><th>CODE PARENT</th><th>ADRESSE</th>';
+		echo '<table class="table table-stripped table-bordered table-condensed" id="cont" style="background-color:white;"><th>NÂ°</th><th>MATRICULE</th><th>NOM</th><th>POSTNOM</th><th>PRENOM</th><th>CODE PARENT</th><th>ADRESSE</th>';
 		
 	while ($resultat = $requete->fetch()){
 		echo '<tr><td>'.$n++.'</td><td><a href="detail.php?id='.$resultat['id'].'">'.$resultat['matr'].'</a></td><td>'.$resultat['nom'].'</td><td>'.$resultat['postnom'].'</td><td>'.$resultat['prenom'].'</td><td>'.$resultat['codep'].'</td><td>'.$resultat['adresse'].'</td></tr>';


### PR DESCRIPTION
## Summary
- fix HTML structure on various PHP pages
- remove leftover `<br />` tags after `</html>`
- position `header.php` includes before `<body>`
- remove empty placeholders

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867edd9c7088320b4568beba51ffdb3